### PR TITLE
Extendeed API with SuccessfulLoginEvent

### DIFF
--- a/src/main/java/com/rabbitcomapny/commands/Login.java
+++ b/src/main/java/com/rabbitcomapny/commands/Login.java
@@ -1,8 +1,10 @@
 package com.rabbitcomapny.commands;
 
 import com.rabbitcomapny.Passky;
+import com.rabbitcomapny.events.SuccessfulLoginEvent;
 import com.rabbitcomapny.utils.Hash;
 import com.rabbitcomapny.utils.Utils;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
@@ -57,6 +59,7 @@ public class Login implements ICommand {
 		player.removePotionEffect(PotionEffectType.BLINDNESS);
 		player.resetTitle();
 		player.sendMessage(Utils.getMessages("prefix") + Utils.getMessages("login_successfully"));
+		Bukkit.getPluginManager().callEvent(new SuccessfulLoginEvent(player));
 
 		if (Passky.getInstance().getConf().getBoolean("session_enabled", false)) {
 			if (player.getAddress() != null && player.getAddress().getAddress() != null)

--- a/src/main/java/com/rabbitcomapny/events/SuccessfulLoginEvent.java
+++ b/src/main/java/com/rabbitcomapny/events/SuccessfulLoginEvent.java
@@ -1,0 +1,22 @@
+package com.rabbitcomapny.events;
+
+import org.bukkit.event.HandlerList;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerEvent;
+
+public class SuccessfulLoginEvent extends PlayerEvent {
+	private static final HandlerList HANDLERS = new HandlerList();
+
+	public SuccessfulLoginEvent(Player player) {
+		super(player);
+	}
+	@Override
+	public HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+
+}

--- a/src/main/java/com/rabbitcomapny/listeners/PlayerJoinListener.java
+++ b/src/main/java/com/rabbitcomapny/listeners/PlayerJoinListener.java
@@ -1,6 +1,7 @@
 package com.rabbitcomapny.listeners;
 
 import com.rabbitcomapny.Passky;
+import com.rabbitcomapny.events.SuccessfulLoginEvent;
 import com.rabbitcomapny.utils.Session;
 import com.rabbitcomapny.utils.Utils;
 import org.bukkit.Bukkit;
@@ -46,6 +47,7 @@ public class PlayerJoinListener implements Listener {
 						Passky.isLoggedIn.put(e.getPlayer().getUniqueId(), true);
 						e.getPlayer().removePotionEffect(PotionEffectType.BLINDNESS);
 						e.getPlayer().sendMessage(Utils.getMessages("prefix") + Utils.getMessages("login_successfully"));
+						Bukkit.getPluginManager().callEvent(new SuccessfulLoginEvent(e.getPlayer()));
 					}
 				}
 			}
@@ -88,5 +90,6 @@ public class PlayerJoinListener implements Listener {
 				}
 			}, Passky.getInstance().getConf().getInt("time_before_kick", 30) * 20L);
 		}
+
 	}
 }


### PR DESCRIPTION
Wrote a small modification for use with my 'homebrew' plugin (to be able to display a Title after the login flow), and I thought that maybe you can find a use for it too. You could extend it with a `FailedLoginEvent` as well, I just didn't see an use case for it.