### PR TITLE
Add option to persist session data to file between restarts

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,6 +31,10 @@ hide_password: true
 session_enabled: true
 # How many minutes do you want session to last?
 session_time: 30
+# Enable session persistence to file between server restarts
+# If true, session data will be saved and restored automatically
+# This setting is ignored if mysql: true
+persist_session: false
 # Do you want to enable titles and subtitles?
 titles_enabled: true
 # This title will show when player is required to login


### PR DESCRIPTION
This PR adds a new configuration option:
```yaml
persist_session: true
```
When enabled, the plugin will save session data to a file, allowing players to stay logged in across server restarts (as long as the session is still valid).
This feature improves session reliability on servers that don’t use MySQL.