### PR TITLE
Add EntityTargetListener to handle entity targeting events

### DIFF
--- a/src/main/java/com/rabbitcomapny/Passky.java
+++ b/src/main/java/com/rabbitcomapny/Passky.java
@@ -125,6 +125,7 @@ public final class Passky extends JavaPlugin {
 		new PlayerHungerListener(this);
 		new PlayerInteractListener(this);
 		new PlayerAttackListener(this);
+		new EntityTargetListener(this);
 	}
 
 	public void setupPasswordFilter() {

--- a/src/main/java/com/rabbitcomapny/listeners/EntityTargetListener.java
+++ b/src/main/java/com/rabbitcomapny/listeners/EntityTargetListener.java
@@ -1,0 +1,27 @@
+package com.rabbitcomapny.listeners;
+
+import com.rabbitcomapny.Passky;
+import com.rabbitcomapny.api.Identifier;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
+
+public class EntityTargetListener implements Listener {
+
+	public EntityTargetListener(Passky plugin) {
+		Bukkit.getPluginManager().registerEvents(this, plugin);
+	}
+
+	@EventHandler
+	public void onEntityTarget(EntityTargetLivingEntityEvent e) {
+		if (e.getTarget() instanceof Player) {
+			Player player = (Player) e.getTarget();
+			if (!Passky.isLoggedIn.getOrDefault(new Identifier(player).toString(), false)) {
+				e.setCancelled(true);
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Fix #15: prevent creepers from reacting to players during login phase.